### PR TITLE
Changes pygments code highlight style

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ language = 'en'
 exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = True


### PR DESCRIPTION
This PR change the pygments code highlight style from `sphinx` to `default`. I think the `default` style looks nicer and is easier to read. 

With `sphinx`:

<img width="1090" alt="screen shot 2018-04-07 at 10 06 30 am" src="https://user-images.githubusercontent.com/11656932/38456590-bd2ab69c-3a4b-11e8-82a5-7dda81d67501.png">

With `default`:

<img width="1087" alt="screen shot 2018-04-07 at 10 07 16 am" src="https://user-images.githubusercontent.com/11656932/38456591-c691bcbc-3a4b-11e8-8131-1ebbc05b3a6d.png">
