### PR TITLE
Adding an overview page to the PyUnfold distribution site

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ The returned unfolded result is a dictionary containing:
     :maxdepth: 1
     :caption: User Guide
 
+    overview
     installation
     api
     callbacks

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -53,10 +53,8 @@ The potential audience for PyUnfold includes natural scientists who are in need 
 statistical and programming framework in which to incorporate the uncertainties of 
 their measurement processes to estimate their desired variables.
 PyUnfold already has been successfully implemented to unfold the cosmic-ray energy 
-spectrum using data from the HAWC_ and IceCube_ observatories.
-
-.. HAWC_: https://www.hawc-observatory.org/
-.. IceCube_: https://icecube.wisc.edu/
+spectrum using data from the `HAWC <https://www.hawc-observatory.org/>`_ and 
+`IceCube <https://icecube.wisc.edu/>`_ observatories.
 
 
 -----

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -2,28 +2,57 @@
 
 :github_url: https://github.com/jrbourbeau/pyunfold
 
-************
+********
 Overview
-************
+********
 
-PyUnfold is a Python language software package for the incorporation of the imperfections
-of the measurement process in the data analysis roadmap.
 
-In an ideal world, scientists would have access to the perfect detector:
+PyUnfold is a Python package for incorporating imperfections
+of the measurement process into a data analysis pipeline. 
+
+
+------------------
+What is unfolding?
+------------------
+
+In an ideal world, we would have access to the perfect detector:
 an apparatus that makes no error in measuring a desired quantity.
-Real detectors have finite resolutions, less than 100% efficiencies, and can have 
-characteristic biases that may not be eliminable, yet themselves can be measured or estimated.
-Statistical uncertainties also propagate through the measurement process, inclusion
-of which typically requires either careful book-keeping or conservative estimates.
+However, in real life, detectors have:
+
+- Finite resolutions
+- Characteristic biases that cannot be eliminated
+- Less than 100% detection efficiencies
+- Statistical uncertainties
 
 By building a matrix that encodes a detector's smearing of the desired true quantity
-into the measured observable(s), a deconvolution can be performed that backs out
-an estimate of the true variable.
+into the measured observable(s), a deconvolution can be performed that provides 
+an estimate of the true variable. This deconvolution process is known as unfolding. 
+
+
+----------------------------
+Iterative Bayesian unfolding
+----------------------------
+
 The unfolding method implemented in PyUnfold accomplishes this deconvolution
 by harnessing the power of Bayes' Theorem in an iterative procedure, providing results
-based on physical expectations of the desired quantity.
+based on physical expectations of the desired quantity [1]_.
 Furthermore, tedious book-keeping for both statistical and systematic errors
-produces precise final uncertainty estimates.
+produces precise final uncertainty estimates. 
+
+
+-----
+Goals
+-----
+
+PyUnfold provides users:
+
+- A tool for the analysis of measurement effects on physical distributions
+- A straightforward API that's suitable for many experimental applications
+- The ability to easily incorporate both statistical and systematic uncertainties
+
+PyUnfold has been successfully used in astroparticle physics measurements by both 
+the `HAWC <https://www.hawc-observatory.org/>`_ and `IceCube <https://icecube.wisc.edu/>`_ 
+observatories.
 
 
 -----------
@@ -31,50 +60,24 @@ Terminology
 -----------
 
 In the measurement process, a true distribution of **causes** is detected by some
-apparatus having a characteristic **response function** or matrix which produces a
+apparatus having a characteristic **response function**, or matrix, which produces a
 *measurable* distribution of **effects**.
-The act unfolding approximates the inverse of the response function by convolving it with
-a **prior** distribution which encodes a guess as to the form of the true cause distribution.
+
+The act of unfolding approximates the inverse of the response function by convolving it with
+a **prior** distribution which encodes a guess at the form of the true cause distribution.
 Including the measured effects distribution, we obtain an updated, better guess of the cause
-distribution.
-This update can be used as a prior for another unfolding, making this an iterative procedure.
-The iterations stop once a test statistic comparing the unfolded cause distribution between 
-two iterations satisties some pre-defined threshold, typically taking just a few iterations.
-One needs only to provide the response matrix, its estimated uncertainties, and the measured 
-effects distribution to use PyUnfold.
+distribution. This updated, better guess can be used as a prior for another unfolding, 
+making this an iterative procedure.
+
+These unfolding iterations continue until some stopping condition (usually a test statistic 
+comparing the unfolded cause distribution between subsequent iterations) satisties some 
+pre-defined threshold, typically taking just a few iterations.
+
+To use PyUnfold, one needs only to provide the
+
+- Measured effects distribution
+- Response matrix
+- Prior distribution
 
 
-
-------------------
-Who uses PyUnfold?
-------------------
-
-The potential audience for PyUnfold includes natural scientists who are in need of a 
-statistical and programming framework in which to incorporate the uncertainties of 
-their measurement processes to estimate their desired variables.
-PyUnfold already has been successfully implemented to unfold the cosmic-ray energy 
-spectrum using data from the `HAWC <https://www.hawc-observatory.org/>`_ and 
-`IceCube <https://icecube.wisc.edu/>`_ observatories.
-
-
------
-Goals
------
-
-PyUnfold is intended to provide experimental scientists
-
-- a generalized tool for the analysis of measurement effects on physical distributions
-- a straightforward programming interface that is suitable for many experimental applications
-- the ability to painlessly incorporate and propagate statistical and systematic uncertainties
-
-
-
--------
-History
--------
-
-The original version of PyUnfold was brought to life by Zigfried Hampel-Arias in early 2016,
-and was later diligently consolidated into its present form by James Bourbeau, both proud UW Badgers.
-The first public release of PyUnfold was made available in April 2018.
-
-
+.. [1] G. D'Agostini, “A Multidimensional unfolding method based on Bayes' theorem”, Nucl. Instrum. Meth. A **362** (1995) 487.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,0 +1,61 @@
+.. _overview:
+
+:github_url: https://github.com/jrbourbeau/pyunfold
+
+************
+Overview
+************
+
+PyUnfold is a Python language software package for the incorporation of the imperfections
+of the measurement process in the data analysis roadmap.
+
+In an ideal world, scientists would have access to the perfect detector:
+an apparatus that makes no error in measuring a desired quantity.
+However, real detectors have finite resolutions and can have characteristic biases that may 
+not be eliminable, yet themselves can be measured or estimated.
+Statistical uncertainties also propagate through the measurement process, inclusion
+of which typically requires either careful book-keeping or conservative estimates.
+
+By building a matrix that encodes a detector's smearing of the desired true quantity
+into the measured observable(s), a deconvolution can be performed that attempts to back out
+an estimate of the true variable.
+The unfolding method implemented in PyUnfold accomplishes this deconvolution
+by harnessing the power of Bayes' Theorem in an iterative procedure, providing results
+based on physical expectations of the true quantity.
+
+
+------------------
+Who uses PyUnfold?
+------------------
+
+The potential audience for PyUnfold includes natural scientists who are in need of a 
+statistical and programming framework in which to incorporate the uncertainties of 
+their measurement processes to estimate their desired variables.
+PyUnfold has been successfully implemented  to unfold the cosmic-ray energy spectrum using data
+from the HAWC_ and IceCube_ observatories.
+
+.. HAWC_: https://www.hawc-observatory.org/
+.. IceCube_: https://icecube.wisc.edu/
+
+
+-----
+Goals
+-----
+
+PyUnfold is intended to provide experimental scientists
+
+- a tool for the analysis of measurement effects on physical distributions
+- a straightforward programming interface that is suitable for many experimental applications
+- the ability to painlessly incorporate and propagate statistical and systematic uncertainties
+
+
+
+-------
+History
+-------
+
+The original version of PyUnfold was brought to life by Zigfried Hampel-Arias in early 2016,
+and was later diligently consolidated into its present form by James Bourbeau, both proud UW Badgers.
+The first public release of PyUnfold was made available in April 2018.
+
+

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -11,17 +11,38 @@ of the measurement process in the data analysis roadmap.
 
 In an ideal world, scientists would have access to the perfect detector:
 an apparatus that makes no error in measuring a desired quantity.
-However, real detectors have finite resolutions and can have characteristic biases that may 
-not be eliminable, yet themselves can be measured or estimated.
+Real detectors have finite resolutions, less than 100% efficiencies, and can have 
+characteristic biases that may not be eliminable, yet themselves can be measured or estimated.
 Statistical uncertainties also propagate through the measurement process, inclusion
 of which typically requires either careful book-keeping or conservative estimates.
 
 By building a matrix that encodes a detector's smearing of the desired true quantity
-into the measured observable(s), a deconvolution can be performed that attempts to back out
+into the measured observable(s), a deconvolution can be performed that backs out
 an estimate of the true variable.
 The unfolding method implemented in PyUnfold accomplishes this deconvolution
 by harnessing the power of Bayes' Theorem in an iterative procedure, providing results
-based on physical expectations of the true quantity.
+based on physical expectations of the desired quantity.
+Furthermore, tedious book-keeping for both statistical and systematic errors
+produces precise final uncertainty estimates.
+
+
+-----------
+Terminology
+-----------
+
+In the measurement process, a true distribution of **causes** is detected by some
+apparatus having a characteristic **response function** or matrix which produces a
+*measurable* distribution of **effects**.
+The act unfolding approximates the inverse of the response function by convolving it with
+a **prior** distribution which encodes a guess as to the form of the true cause distribution.
+Including the measured effects distribution, we obtain an updated, better guess of the cause
+distribution.
+This update can be used as a prior for another unfolding, making this an iterative procedure.
+The iterations stop once a test statistic comparing the unfolded cause distribution between 
+two iterations satisties some pre-defined threshold, typically taking just a few iterations.
+One needs only to provide the response matrix, its estimated uncertainties, and the measured 
+effects distribution to use PyUnfold.
+
 
 
 ------------------
@@ -31,8 +52,8 @@ Who uses PyUnfold?
 The potential audience for PyUnfold includes natural scientists who are in need of a 
 statistical and programming framework in which to incorporate the uncertainties of 
 their measurement processes to estimate their desired variables.
-PyUnfold has been successfully implemented  to unfold the cosmic-ray energy spectrum using data
-from the HAWC_ and IceCube_ observatories.
+PyUnfold already has been successfully implemented to unfold the cosmic-ray energy 
+spectrum using data from the HAWC_ and IceCube_ observatories.
 
 .. HAWC_: https://www.hawc-observatory.org/
 .. IceCube_: https://icecube.wisc.edu/
@@ -44,7 +65,7 @@ Goals
 
 PyUnfold is intended to provide experimental scientists
 
-- a tool for the analysis of measurement effects on physical distributions
+- a generalized tool for the analysis of measurement effects on physical distributions
 - a straightforward programming interface that is suitable for many experimental applications
 - the ability to painlessly incorporate and propagate statistical and systematic uncertainties
 


### PR DESCRIPTION
Added some general introductory material for an overview section on the userguide page