### PR TITLE
Adds prior setup function

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Version 0.2.dev0 (TBD)
 
 - Added ``Logger`` callback to write test statistic information to stdout. (See `PR #18 <https://github.com/jrbourbeau/pyunfold/pull/18>`_)
 - Added contributing guide to the documentation page. (See `PR #31 <https://github.com/jrbourbeau/pyunfold/pull/31>`_)
+- Added ``setup_prior`` convenience function to help validate user prior input (See `PR #35 <https://github.com/jrbourbeau/pyunfold/pull/35>`_)
 
 **Changes**:
 

--- a/pyunfold/priors.py
+++ b/pyunfold/priors.py
@@ -1,6 +1,8 @@
 
 from __future__ import division, print_function
 import numpy as np
+from six import string_types
+import pandas as pd
 
 
 def jeffreys_prior(norm, xarray):
@@ -8,20 +10,47 @@ def jeffreys_prior(norm, xarray):
     """
     # All cause bins are given equal probability.
     # Best prior for x-ranges spanning decades.
-    ilen = len(xarray)
-    ln_factor = np.log(xarray[ilen - 1] / xarray[0])
-    jprior = norm / (ln_factor * xarray)
+    ln_factor = np.log(xarray[-1] / xarray[0])
+    prior = norm / (ln_factor * xarray)
+    # Want to make sure prior is normalized (i.e. prior.sum() == 1)
+    prior = prior / prior.sum()
 
-    return jprior
+    return prior
 
 
-def user_prior(func, xarray, norm):
-    """User provided prior function
+def setup_prior(priors='Jeffreys', num_causes=None, num_observations=None):
+    """Setup for prior array
+
+    Parameters
+    ----------
+    priors : str or array_like, optional
+        Prior distribution to use (default is 'Jeffreys', will use Jeffreys
+        prior).
+    num_causes : int, optional
+        Number of cause bins. Only needed if priors='Jeffreys' (default is None).
+    num_observations : int, optional
+        Number of total effect observations. Only needed if priors='Jeffreys'
+        (default is None).
+
+    Returns
+    -------
+    prior : numpy.ndarray
+        Normalized prior distribution.
     """
-    if func.lower() == "jeffreys":
-        prior = jeffreys_prior(norm, xarray)
+    if isinstance(priors, string_types) and priors.lower() == 'jeffreys':
+        assert num_causes is not None, 'num_causes must be specified for Jeffreys prior'
+        assert num_observations is not None, 'num_observations must be specified for Jeffreys prior'
+        cause_bin_edges = np.arange(num_causes + 1, dtype=float)
+        cause_axis = (cause_bin_edges[1:] + cause_bin_edges[:-1]) / 2
+        prior = jeffreys_prior(norm=num_observations, xarray=cause_axis)
+    elif isinstance(priors, (list, tuple, np.ndarray, pd.Series)):
+        prior = np.asarray(priors)
     else:
-        exec("def func(x): return {}".format(func))
-        prior = func(xarray)
+        raise TypeError('priors must be either "Jeffreys" or array_like, '
+                        'but got {}'.format(type(priors)))
+
+    if not np.allclose(np.sum(prior), 1):
+        raise ValueError('Prior (which is an array of probabilities) does '
+                         'not add to 1. sum(prior) = {}'.format(np.sum(prior)))
 
     return prior

--- a/pyunfold/tests/test_priors.py
+++ b/pyunfold/tests/test_priors.py
@@ -1,0 +1,49 @@
+
+from __future__ import division, print_function
+import pytest
+import numpy as np
+
+from pyunfold.priors import jeffreys_prior, setup_prior
+
+
+@pytest.mark.parametrize('prior', ['not jeffreys',
+                                   123,
+                                   123.0])
+def test_setup_prior_invalid_prior(prior):
+    with pytest.raises(TypeError) as excinfo:
+        setup_prior(prior)
+    expected_msg = ('priors must be either "Jeffreys" or array_like, '
+                    'but got {}'.format(type(prior)))
+    assert expected_msg == str(excinfo.value)
+
+
+def test_setup_prior_non_normalized_raises():
+    prior = [1, 2, 3, 4]
+    with pytest.raises(ValueError) as excinfo:
+        setup_prior(prior)
+    expected_msg = ('Prior (which is an array of probabilities) does '
+                    'not add to 1. sum(prior) = {}'.format(np.sum(prior)))
+    assert expected_msg == str(excinfo.value)
+
+
+@pytest.mark.parametrize('prior', ['jeffreys',
+                                   'Jeffreys',
+                                   'JEFFREYS'])
+def test_setup_prior_jeffreys_prior_spelling(prior):
+    setup_prior(prior, num_causes=10, num_observations=10)
+
+
+@pytest.mark.parametrize('num_causes,num_observations', [(10, None),
+                                                         (None, 10)])
+def test_setup_prior_jeffreys_prior_extra_raises(num_causes, num_observations):
+    with pytest.raises(AssertionError):
+        setup_prior('jeffreys',
+                    num_causes=num_causes,
+                    num_observations=num_observations)
+
+
+def test_jeffreys_prior_normalized():
+    xarray = np.array([0.5, 1.5])
+    prior = jeffreys_prior(norm=10, xarray=xarray)
+
+    np.testing.assert_allclose(prior.sum(), 1)

--- a/pyunfold/teststat.py
+++ b/pyunfold/teststat.py
@@ -11,15 +11,19 @@ from .utils import none_to_empty_list
 class TestStat(object):
     """Common base class for test statistic methods
     """
-    def __init__(self, name="TestStat", tol=None, Xaxis=None, TestRange=None,
-                 verbose=False, **kwargs):
-        Xaxis, TestRange = none_to_empty_list(Xaxis, TestRange)
+    def __init__(self, name="TestStat", tol=None, num_causes=None,
+                 TestRange=None, verbose=False, **kwargs):
+        TestRange = none_to_empty_list(TestRange)
         # TS Name
         self.name = name
         # User Defined TS Tolerance
         self.tol = tol
-        # User Provided Xaxis and Test Range
-        self.Xaxis = Xaxis.copy()
+        if num_causes is None:
+            raise ValueError('Number of causes (num_causes) must be provided.')
+        cause_bin_edges = np.arange(num_causes + 1, dtype=float)
+        # Get bin midpoints
+        cause_axis = (cause_bin_edges[1:] + cause_bin_edges[:-1]) / 2
+        self.Xaxis = cause_axis
         self.TSRange = TestRange
         self.IsRangeTS = False
         self.TSbins = self.SetTestRangeBins()


### PR DESCRIPTION
This PR adds a `setup_prior()` function to the `priors` module. This function handles calculating the Jeffreys prior (if specified) and user input validation. 