### PR TITLE
Make iterative_unfold inputs keyword arguments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,24 @@
 Release Notes
 *************
 
+Version 0.3.dev0 (TBD)
+----------------------
+
+**New Features**:
+
+-
+
+**Changes**:
+
+- Makes ``data``, ``response``, ``efficiencies``, and associated uncertainties
+  parameters in ``iterative_unfold`` keyword arguments. Now they can be input
+  in any order. (See `PR #46 <https://github.com/jrbourbeau/pyunfold/pull/46>`_)
+
+**Bug Fixes**:
+
+-
+
+
 Version 0.2.2 (2018-05-04)
 --------------------------
 

--- a/pyunfold/__version__.py
+++ b/pyunfold/__version__.py
@@ -1,2 +1,2 @@
 
-__version__ = '0.2.2'
+__version__ = '0.3.dev0'

--- a/pyunfold/tests/test_unfold.py
+++ b/pyunfold/tests/test_unfold.py
@@ -158,3 +158,33 @@ def test_example_non_square_response():
     unfolded = unfolded[columns]
 
     pd.testing.assert_frame_equal(unfolded, expected)
+
+
+inputs = ['data', 'data_err', 'response', 'response_err', 'efficiencies', 'efficiencies_err']
+
+
+@pytest.mark.parametrize('none_input', inputs)
+def test_iterative_unfold_none_input_raises(none_input):
+    # Load test counts distribution and diagonal response matrix
+    np.random.seed(2)
+    samples = np.random.normal(loc=0, scale=1, size=int(1e5))
+
+    bins = np.linspace(-1, 1, 10)
+    data, _ = np.histogram(samples, bins=bins)
+    data_err = np.sqrt(data)
+    response, response_err = diagonal_response(len(data))
+    efficiencies = np.ones_like(data, dtype=float)
+    efficiencies_err = np.full_like(efficiencies, 0.001)
+
+    inputs = {'data': data,
+              'data_err': data_err,
+              'response': response,
+              'response_err': response_err,
+              'efficiencies': efficiencies,
+              'efficiencies_err': efficiencies_err
+              }
+    inputs[none_input] = None
+    with pytest.raises(ValueError) as excinfo:
+        iterative_unfold(**inputs)
+    expected_msg = 'The input for "{}" must not be None.'.format(none_input)
+    assert expected_msg == str(excinfo.value)

--- a/pyunfold/tests/test_utils.py
+++ b/pyunfold/tests/test_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from pyunfold.utils import (none_to_empty_list, safe_inverse, cast_to_array,
-                            assert_same_shape, assert_kwargs_not_none)
+                            assert_same_shape)
 
 
 def test_none_to_empty_list_single_input():
@@ -75,22 +75,3 @@ def test_assert_same_shape_raises_2d():
     b = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     with pytest.raises(ValueError):
         assert_same_shape(a, b)
-
-
-def test_assert_kwargs_not_none_passes():
-
-    @assert_kwargs_not_none()
-    def example_func(a, b=None, c=None):
-        return
-
-    example_func(10)
-
-
-def test_assert_kwargs_not_none_raises():
-
-    @assert_kwargs_not_none('b', 'c')
-    def example_func(a, b=None, c=None):
-        return
-
-    with pytest.raises(ValueError):
-        example_func(10)

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -10,8 +10,9 @@ from .utils import cast_to_array
 from .callbacks import validate_callbacks, extract_regularizer
 
 
-def iterative_unfold(data, data_err, response, response_err, efficiencies,
-                     efficiencies_err, priors='Jeffreys', ts='ks',
+def iterative_unfold(data=None, data_err=None, response=None,
+                     response_err=None, efficiencies=None,
+                     efficiencies_err=None, priors='Jeffreys', ts='ks',
                      ts_stopping=0.01, max_iter=100, return_iterations=False,
                      callbacks=None):
     """Performs iterative Bayesian unfolding
@@ -21,22 +22,24 @@ def iterative_unfold(data, data_err, response, response_err, efficiencies,
     data : array_like
         Input observed data distribution.
     data_err : array_like
-        Uncertainties associated with the input observed data distribution.
-        Must be the same shape as data.
+        Uncertainties of the input observed data distribution. Must be the
+        same shape as ``data``.
     response : array_like
         Response matrix.
     response_err : array_like
-        Response matrix errors.
+        Uncertainties of response matrix. Must be the same shape as
+        ``response``.
     efficiencies : array_like
-        Detection efficiencies for the observed data distribution.
+        Detection efficiencies for the cause distribution.
     efficiencies_err : array_like
-        Uncertainty in detection efficiencies.
+        Uncertainties of detection efficiencies. Must be the same shape as
+        ``efficiencies``.
     priors : str or array_like, optional
-        Prior distribution to use in unfolding. If 'Jeffreys', then the
+        Prior distribution to use in unfolding. If ``'Jeffreys'``, then the
         Jeffreys (flat) prior is used. Otherwise, must be array_like with
-        same shape as data (default is 'Jeffreys').
+        same shape as ``efficiencies`` (default is 'Jeffreys').
     ts : {'ks', 'chi2', 'pf', 'rmd'}
-        Name of test statistic to use for stopping condition (default is 'ks').
+        Name of test statistic to use for stopping condition (default is ``'ks'``).
     ts_stopping : float, optional
         Test statistic stopping condition. At each unfolding iteration, the
         test statistic is computed between the current and previous iteration.
@@ -54,10 +57,10 @@ def iterative_unfold(data, data_err, response, response_err, efficiencies,
     Returns
     -------
     unfolded_result : dict
-        Returned if return_iterations is False (default). Final unfolded
+        Returned if ``return_iterations`` is False (default). Final unfolded
         distribution and associated uncertainties.
     unfolding_iters : pandas.DataFrame
-        Returned if return_iterations is True. DataFrame containing the
+        Returned if ``return_iterations`` is True. DataFrame containing the
         unfolded distribution and associated uncertainties at each iteration.
 
     Examples
@@ -80,6 +83,17 @@ def iterative_unfold(data, data_err, response, response_err, efficiencies,
     'stat_err': array([11.2351567 , 13.75617997])}
     """
     # Validate user input
+    inputs = {'data': data,
+              'data_err': data_err,
+              'response': response,
+              'response_err': response_err,
+              'efficiencies': efficiencies,
+              'efficiencies_err': efficiencies_err
+              }
+    for name in inputs:
+        if inputs[name] is None:
+            raise ValueError('The input for "{}" must not be None.'.format(name))
+
     data, data_err = cast_to_array(data, data_err)
     response, response_err = cast_to_array(response, response_err)
     efficiencies, efficiencies_err = cast_to_array(efficiencies,

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -35,11 +35,11 @@ def iterative_unfold(data=None, data_err=None, response=None,
         Uncertainties of detection efficiencies. Must be the same shape as
         ``efficiencies``.
     priors : str or array_like, optional
-        Prior distribution to use in unfolding. If ``'Jeffreys'``, then the
+        Prior distribution to use in unfolding. If 'Jeffreys', then the
         Jeffreys (flat) prior is used. Otherwise, must be array_like with
         same shape as ``efficiencies`` (default is 'Jeffreys').
     ts : {'ks', 'chi2', 'pf', 'rmd'}
-        Name of test statistic to use for stopping condition (default is ``'ks'``).
+        Name of test statistic to use for stopping condition (default is 'ks').
     ts_stopping : float, optional
         Test statistic stopping condition. At each unfolding iteration, the
         test statistic is computed between the current and previous iteration.
@@ -74,9 +74,12 @@ def iterative_unfold(data=None, data_err=None, response=None,
     ...                 [0.01, 0.01]]
     >>> efficiencies = [1, 1]
     >>> efficiencies_err = [0.01, 0.01]
-    >>> unfolded = iterative_unfold(data, data_err,
-    ...                             response, response_err,
-    ...                             efficiencies, efficiencies_err)
+    >>> unfolded = iterative_unfold(data=data,
+    ...                             data_err=data_err,
+    ...                             response=response,
+    ...                             response_err=response_err,
+    ...                             efficiencies=efficiencies,
+    ...                             efficiencies_err=efficiencies_err)
     >>> unfolded
     {'unfolded': array([ 94.48002622, 155.51997378]),
     'sys_err': array([0.66204237, 0.6620424 ]),

--- a/pyunfold/utils.py
+++ b/pyunfold/utils.py
@@ -1,43 +1,6 @@
 
 from __future__ import division, print_function
-from functools import wraps
-import inspect
 import numpy as np
-
-
-def assert_kwargs_not_none(*inputs):
-    """Decorator to wrap functions that require non-None kwargs
-
-    Parameters
-    ----------
-    inputs : str
-        Name of keyword arguments to check for non-None values.
-
-    Raises
-    ------
-    ValueError
-        If one of the ``inputs`` keyword arguments is None.
-    """
-    def real_decorator(func):
-        # Want to build list of keyword arguments from the func signature
-        argspec = inspect.getargspec(func)
-        sig_kwarg_keys = argspec.args[-len(argspec.defaults):]
-        sig_kwarg_values = argspec.defaults
-        sig_kwargs = dict(zip(sig_kwarg_keys, sig_kwarg_values))
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            for input_ in inputs:
-                err_msg = 'Input keyword argument "{}" must not be None'.format(input_)
-                try:
-                    if kwargs[input_] is None:
-                        raise ValueError(err_msg)
-                except KeyError:
-                    if sig_kwargs[input_] is None:
-                        raise ValueError(err_msg)
-            return func(*args, **kwargs)
-        return wrapper
-    return real_decorator
 
 
 def assert_same_shape(*arrays):


### PR DESCRIPTION
This PR makes ``data``, ``response``, ``efficiencies``, and associated uncertainties parameters in ``iterative_unfold`` keyword arguments. So now users can input them in any order.