### PR TITLE
Adds groups to SplineRegularizer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,8 @@ Version 0.3.dev0 (TBD)
 
 **New Features**:
 
--
+- Adds cause bin group support to ``SplineRegularizer`` for independent
+  regularization. (See `PR #47 <https://github.com/jrbourbeau/pyunfold/pull/47>`_)
 
 **Changes**:
 

--- a/pyunfold/callbacks.py
+++ b/pyunfold/callbacks.py
@@ -80,6 +80,10 @@ class SplineRegularizer(Callback, Regularizer):
         Group labels for each cause bin. If groups are specified, then each
         cause group will be regularized independently (default is None).
 
+    Notes
+    -----
+    The number of causes must be larger than the spline ``degree``.
+
     Examples
     --------
     Specify the spline degree and smoothing factor:

--- a/pyunfold/callbacks.py
+++ b/pyunfold/callbacks.py
@@ -112,6 +112,12 @@ class SplineRegularizer(Callback, Regularizer):
             spline = UnivariateSpline(x, y, k=self.degree, s=self.smooth)
             fitted_unfolded = spline(x)
         else:
+            # Check that a group is specified for each cause bin
+            if len(self.groups) != len(y):
+                err_msg = ('Invalid groups array. There should be an entry '
+                           'for each cause bin. However, got len(groups)={} '
+                           'while there are {} cause bins.'.format(len(self.groups), len(y)))
+                raise ValueError(err_msg)
             fitted_unfolded = np.empty(len(y))
             group_ids = np.unique(self.groups)
             for group in group_ids:

--- a/pyunfold/tests/test_callbacks.py
+++ b/pyunfold/tests/test_callbacks.py
@@ -131,8 +131,8 @@ def test_SplineRegularizer_groups(example_dataset):
     degree = 3
     smooth = 20
     groups = np.empty_like(example_dataset.data)
-    groups[:len(example_dataset.data) // 2] = 0
-    groups[len(example_dataset.data) // 2:] = 1
+    groups[:len(groups) // 2] = 0
+    groups[len(groups) // 2:] = 1
     spline_reg = SplineRegularizer(degree=degree, smooth=smooth, groups=groups)
     unfolded_with_reg = iterative_unfold(data=example_dataset.data,
                                          data_err=example_dataset.data_err,
@@ -165,6 +165,30 @@ def test_SplineRegularizer_groups(example_dataset):
 
     np.testing.assert_allclose(unfolded_with_reg.iloc[0]['unfolded'],
                                fitted_unfolded_no_reg)
+
+
+def test_SplineRegularizer_groups_raises(example_dataset):
+    degree = 3
+    smooth = 20
+    groups = np.empty(len(example_dataset.data) - 1)
+    groups[:len(groups) // 2] = 0
+    groups[len(groups) // 2:] = 1
+    spline_reg = SplineRegularizer(degree=degree, smooth=smooth, groups=groups)
+    with pytest.raises(ValueError) as excinfo:
+        iterative_unfold(data=example_dataset.data,
+                         data_err=example_dataset.data_err,
+                         response=example_dataset.response,
+                         response_err=example_dataset.response_err,
+                         efficiencies=example_dataset.efficiencies,
+                         efficiencies_err=example_dataset.efficiencies_err,
+                         return_iterations=True,
+                         callbacks=[spline_reg])
+
+    err_msg = ('Invalid groups array. There should be an entry '
+               'for each cause bin. However, got len(groups)={} '
+               'while there are {} cause bins.'.format(len(groups),
+                                                       len(example_dataset.data)))
+    assert err_msg == str(excinfo.value)
 
 
 def test_validate_callbacks():


### PR DESCRIPTION
Closes #34. This PR adds cause bin group support to `SplineRegularizer`. Each group is independently regularized at each unfolding iteration. 
