### PR TITLE
Adds covariance matrix type parameter to iterative_unfold

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,10 @@ Version 0.3.dev0 (TBD)
 
 **New Features**:
 
--
+- Adds ``cov_type`` parameter to the ``iterative_unfold`` function. This adds
+  the option to choose between using the Multinomial or Poisson form of the
+  covariance matrix.
+  (See `PR #50 <https://github.com/jrbourbeau/pyunfold/pull/50>`_)
 
 **Changes**:
 

--- a/pyunfold/tests/conftest.py
+++ b/pyunfold/tests/conftest.py
@@ -1,0 +1,2 @@
+
+from .fixtures import example_dataset

--- a/pyunfold/tests/fixtures.py
+++ b/pyunfold/tests/fixtures.py
@@ -1,0 +1,41 @@
+
+from collections import namedtuple
+import numpy as np
+import pytest
+
+
+@pytest.fixture()
+def example_dataset():
+    data_attributes = ['data',
+                       'data_err',
+                       'response',
+                       'response_err',
+                       'efficiencies',
+                       'efficiencies_err',
+                       ]
+    ExampleInput = namedtuple('ExampleInput', data_attributes)
+
+    num_samples = int(1e4)
+    true_samples = np.random.normal(loc=0.0, scale=1.0, size=num_samples)
+    random_noise = np.random.normal(loc=0.3, scale=0.5, size=num_samples)
+    observed_samples = true_samples + random_noise
+    bins = np.linspace(-3, 3, 21)
+    data_true, _ = np.histogram(true_samples, bins=bins)
+    data_true = np.array(data_true, dtype=float)
+    data, _ = np.histogram(observed_samples, bins=bins)
+    data_err = np.sqrt(data)
+    response, _, _ = np.histogram2d(observed_samples, true_samples, bins=bins)
+    response_err = np.sqrt(response)
+    response = response / response.sum(axis=0)
+    response_err = response_err / response.sum(axis=0)
+    efficiencies = response.sum(axis=0)
+    efficiencies_err = np.full_like(efficiencies, 0.1, dtype=float)
+
+    example = ExampleInput(data=data,
+                           data_err=data_err,
+                           response=response,
+                           response_err=response_err,
+                           efficiencies=efficiencies,
+                           efficiencies_err=efficiencies_err)
+
+    return example

--- a/pyunfold/tests/test_callbacks.py
+++ b/pyunfold/tests/test_callbacks.py
@@ -1,6 +1,5 @@
 
 from __future__ import division, print_function
-from collections import namedtuple
 import numpy as np
 import pytest
 from scipy.interpolate import UnivariateSpline
@@ -9,43 +8,6 @@ from pyunfold.unfold import iterative_unfold
 from pyunfold.callbacks import (Callback, Logger, SplineRegularizer,
                                 Regularizer, validate_callbacks,
                                 extract_regularizer)
-
-
-@pytest.fixture()
-def example_dataset():
-    data_attributes = ['data',
-                       'data_err',
-                       'response',
-                       'response_err',
-                       'efficiencies',
-                       'efficiencies_err',
-                       ]
-    ExampleInput = namedtuple('ExampleInput', data_attributes)
-
-    num_samples = int(1e4)
-    true_samples = np.random.normal(loc=0.0, scale=1.0, size=num_samples)
-    random_noise = np.random.normal(loc=0.3, scale=0.5, size=num_samples)
-    observed_samples = true_samples + random_noise
-    bins = np.linspace(-3, 3, 21)
-    data_true, _ = np.histogram(true_samples, bins=bins)
-    data_true = np.array(data_true, dtype=float)
-    data, _ = np.histogram(observed_samples, bins=bins)
-    data_err = np.sqrt(data)
-    response, _, _ = np.histogram2d(observed_samples, true_samples, bins=bins)
-    response_err = np.sqrt(response)
-    response = response / response.sum(axis=0)
-    response_err = response_err / response.sum(axis=0)
-    efficiencies = response.sum(axis=0)
-    efficiencies_err = np.full_like(efficiencies, 0.1, dtype=float)
-
-    example = ExampleInput(data=data,
-                           data_err=data_err,
-                           response=response,
-                           response_err=response_err,
-                           efficiencies=efficiencies,
-                           efficiencies_err=efficiencies_err)
-
-    return example
 
 
 @pytest.mark.parametrize('attr', ['on_unfolding_begin',

--- a/pyunfold/tests/test_unfold.py
+++ b/pyunfold/tests/test_unfold.py
@@ -179,8 +179,10 @@ def test_iterative_unfold_none_input_raises(none_input, example_dataset):
     assert expected_msg == str(excinfo.value)
 
 
-@pytest.mark.parametrize('cov_type', ['multinomial', 'Multinomial', 'poisson', 'Poisson'])
-def test_iterative_unfold_cov_type_passes(cov_type, example_dataset):
+@pytest.mark.parametrize('cov_type_1,cov_type_2', [('multinomial', 'Multinomial'),
+                                                   ('poisson', 'Poisson')])
+def test_iterative_unfold_cov_type_case_insensitive(cov_type_1, cov_type_2, example_dataset):
+    # Test that cov_type is case insensitive
     inputs = {'data': example_dataset.data,
               'data_err': example_dataset.data_err,
               'response': example_dataset.response,
@@ -188,7 +190,15 @@ def test_iterative_unfold_cov_type_passes(cov_type, example_dataset):
               'efficiencies': example_dataset.efficiencies,
               'efficiencies_err': example_dataset.efficiencies_err
               }
-    iterative_unfold(cov_type=cov_type, **inputs)
+    result_1 = iterative_unfold(cov_type=cov_type_1, **inputs)
+    result_2 = iterative_unfold(cov_type=cov_type_2, **inputs)
+
+    assert result_1.keys() == result_2.keys()
+    for key in result_1.keys():
+        if isinstance(result_1[key], np.ndarray):
+            np.testing.assert_array_equal(result_1[key], result_2[key])
+        else:
+            assert result_1[key] == result_2[key]
 
 
 def test_iterative_unfold_cov_type_raises(example_dataset):

--- a/pyunfold/tests/test_unfold.py
+++ b/pyunfold/tests/test_unfold.py
@@ -164,27 +164,44 @@ inputs = ['data', 'data_err', 'response', 'response_err', 'efficiencies', 'effic
 
 
 @pytest.mark.parametrize('none_input', inputs)
-def test_iterative_unfold_none_input_raises(none_input):
-    # Load test counts distribution and diagonal response matrix
-    np.random.seed(2)
-    samples = np.random.normal(loc=0, scale=1, size=int(1e5))
-
-    bins = np.linspace(-1, 1, 10)
-    data, _ = np.histogram(samples, bins=bins)
-    data_err = np.sqrt(data)
-    response, response_err = diagonal_response(len(data))
-    efficiencies = np.ones_like(data, dtype=float)
-    efficiencies_err = np.full_like(efficiencies, 0.001)
-
-    inputs = {'data': data,
-              'data_err': data_err,
-              'response': response,
-              'response_err': response_err,
-              'efficiencies': efficiencies,
-              'efficiencies_err': efficiencies_err
+def test_iterative_unfold_none_input_raises(none_input, example_dataset):
+    inputs = {'data': example_dataset.data,
+              'data_err': example_dataset.data_err,
+              'response': example_dataset.response,
+              'response_err': example_dataset.response_err,
+              'efficiencies': example_dataset.efficiencies,
+              'efficiencies_err': example_dataset.efficiencies_err
               }
     inputs[none_input] = None
     with pytest.raises(ValueError) as excinfo:
         iterative_unfold(**inputs)
     expected_msg = 'The input for "{}" must not be None.'.format(none_input)
+    assert expected_msg == str(excinfo.value)
+
+
+@pytest.mark.parametrize('cov_type', ['multinomial', 'Multinomial', 'poisson', 'Poisson'])
+def test_iterative_unfold_cov_type_passes(cov_type, example_dataset):
+    inputs = {'data': example_dataset.data,
+              'data_err': example_dataset.data_err,
+              'response': example_dataset.response,
+              'response_err': example_dataset.response_err,
+              'efficiencies': example_dataset.efficiencies,
+              'efficiencies_err': example_dataset.efficiencies_err
+              }
+    iterative_unfold(cov_type=cov_type, **inputs)
+
+
+def test_iterative_unfold_cov_type_raises(example_dataset):
+    inputs = {'data': example_dataset.data,
+              'data_err': example_dataset.data_err,
+              'response': example_dataset.response,
+              'response_err': example_dataset.response_err,
+              'efficiencies': example_dataset.efficiencies,
+              'efficiencies_err': example_dataset.efficiencies_err
+              }
+    cov_type = 'Not a valid cov_type'
+    with pytest.raises(ValueError) as excinfo:
+        iterative_unfold(cov_type=cov_type, **inputs)
+    expected_msg = ('Invalid pec_cov_type entered: {}. Must be '
+                    'either "multinomial" or "poisson".'.format(cov_type))
     assert expected_msg == str(excinfo.value)

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -13,8 +13,8 @@ from .callbacks import validate_callbacks, extract_regularizer
 def iterative_unfold(data=None, data_err=None, response=None,
                      response_err=None, efficiencies=None,
                      efficiencies_err=None, priors='Jeffreys', ts='ks',
-                     ts_stopping=0.01, max_iter=100, return_iterations=False,
-                     callbacks=None):
+                     ts_stopping=0.01, max_iter=100, cov_type='multinomial',
+                     return_iterations=False, callbacks=None):
     """Performs iterative Bayesian unfolding
 
     Parameters
@@ -47,6 +47,9 @@ def iterative_unfold(data=None, data_err=None, response=None,
         procedure is stopped (default is 0.01).
     max_iter : int, optional
         Maximum number of iterations to allow (default is 100).
+    cov_type : {'multinomial', 'poisson'}
+        Whether to use the Multinomial or Poisson form for the covariance
+        matrix (default is 'multinomial').
     return_iterations : bool, optional
         Whether to return unfolded distributions for each iteration
         (default is False).
@@ -110,13 +113,14 @@ def iterative_unfold(data=None, data_err=None, response=None,
                       num_observations=np.sum(data))
 
     # Setup Mixer
-    mixer = Mixer(error_type='ACM',
-                  data=data,
+    mixer = Mixer(data=data,
                   data_err=data_err,
                   efficiencies=efficiencies,
                   efficiencies_err=efficiencies_err,
                   response=response,
-                  response_err=response_err)
+                  response_err=response_err,
+                  cov_type=cov_type,
+                  error_type='ACM')
 
     # Setup test statistic
     ts_obj = get_ts(ts)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,5 +15,5 @@ source =
 precision = 2
 
 [flake8]
-exclude = __init__.py,__pycache__
+exclude = __init__.py,__pycache__,*conftest.py
 max-line-length = 100


### PR DESCRIPTION
This PR adds a `cov_type` parameter to the `iterative_unfold` function. This gives users the option to use with the Multinomial or Poisson form for the covariance matrix. 

Closes #48. 