### PR TITLE
Remove D'Agostini error calculation option 

### DIFF
--- a/pyunfold/mix.py
+++ b/pyunfold/mix.py
@@ -238,8 +238,6 @@ class CovarianceMatrix(object):
                     cov1 = -nc_inv[ti] * self.pec[ej, ti]
                     for ek in range(ej+1, ebins):
                         ekc = ek * cbins
-                        if ejc+ti == ekc+ti or ek == ej:
-                            continue
                         cov = cov1 * self.pec[ek, ti]
                         CovPP[ejc+ti, ekc+ti] = cov
                         CovPP[ekc+ti, ejc+ti] = cov

--- a/pyunfold/tests/test_mix.py
+++ b/pyunfold/tests/test_mix.py
@@ -17,13 +17,13 @@ np.random.seed(2)
 response = 1 + np.random.rand(num_effects, num_causes)
 response_err = np.sqrt(response)
 
-mixer = Mixer(error_type='ACM',
-              data=data,
+mixer = Mixer(data=data,
               data_err=data_err,
               efficiencies=efficiencies,
               efficiencies_err=efficiencies_err,
               response=response,
-              response_err=response_err)
+              response_err=response_err,
+              cov_type='multinomial')
 
 
 def test_mixer_invalid_effects_bins_raises():
@@ -32,8 +32,7 @@ def test_mixer_invalid_effects_bins_raises():
     data_err = np.sqrt(data)
 
     with pytest.raises(ValueError) as excinfo:
-        Mixer(error_type='ACM',
-              data=data,
+        Mixer(data=data,
               data_err=data_err,
               efficiencies=efficiencies,
               efficiencies_err=efficiencies_err,
@@ -50,8 +49,7 @@ def test_mixer_smear_invalid_cause_bins_raises():
     # Add extra cause bin
     prior = np.arange(num_causes + 1)
 
-    mixer = Mixer(error_type='ACM',
-                  data=data,
+    mixer = Mixer(data=data,
                   data_err=data_err,
                   efficiencies=efficiencies,
                   efficiencies_err=efficiencies_err,

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -120,8 +120,7 @@ def iterative_unfold(data=None, data_err=None, response=None,
                   efficiencies_err=efficiencies_err,
                   response=response,
                   response_err=response_err,
-                  cov_type=cov_type,
-                  error_type='ACM')
+                  cov_type=cov_type)
 
     # Setup test statistic
     ts_obj = get_ts(ts)


### PR DESCRIPTION
Removes option to perform covariance matrix error propogation without additional Adye corrections. See https://github.com/jrbourbeau/pyunfold/issues/48#issuecomment-388195922 for discussion. 