### PR TITLE
JOSS review-Fixes environment used in binder examples

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,7 @@
+name: binder_env
+channels:
+  - conda-forge
+dependencies:
+  - matplotlib
+  - pip:
+      - git+https://github.com/jrbourbeau/pyunfold.git

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,7 +19,8 @@ Version 0.4.dev0 (TBD)
 
 **Bug Fixes**:
 
--
+- Fixes environment used for running the "Tutorial" and "Advanced Techniques"
+  example notebooks on binder. (See `PR #68 <https://github.com/jrbourbeau/pyunfold/pull/68>`_)
 
 
 Version 0.3 (2018-05-15)


### PR DESCRIPTION
This PR makes sure PyUnfold is installed for the "Tutorial" and "Advanced Techniques" section notebooks when running on binder. 

Fixes #67 
ref: https://github.com/openjournals/joss-reviews/issues/741#issuecomment-392306025