### PR TITLE
Adding et al. for cosmic ray paper ref

### DIFF
--- a/docs/joss_paper/paper.bib
+++ b/docs/joss_paper/paper.bib
@@ -86,7 +86,7 @@
 
 @article{hawc-crspectrum,
   title = {All-particle cosmic ray energy spectrum measured by the {HAWC} experiment from 10 to 500 TeV},
-  author = {{Alfaro, R.} and others},
+  author = {{Alfaro, R.} et al.},
   collaboration = {HAWC Collaboration},
   journal = {Phys. Rev. D},
   volume = {96},


### PR DESCRIPTION
Latex compilation of paper doesn't recognize 'and others' as et al, so I hard coded it as the author list for the HAWC cosmic ray spectrum in the bibliography.