### PR TITLE
Add unfolding matrix to output

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,7 +11,7 @@ Version 0.5.dev0 (TBD)
 
 **New Features**:
 
--
+- Adds unfolding matrix to output of ``iterative_unfold`` (See `PR #88 <https://github.com/jrbourbeau/pyunfold/pull/88>`_).
 
 
 **Changes**:

--- a/pyunfold/tests/test_unfold.py
+++ b/pyunfold/tests/test_unfold.py
@@ -260,6 +260,21 @@ def test_iterative_unfold_keys(example_dataset, return_iterations):
             'num_iterations',
             'ts_stopping',
             'ts_iter',
+            'unfolding_matrix',
             ]
     for key in keys:
         assert key in unfolded_result
+
+
+def test_unfolding_matrix(example_dataset):
+    inputs = {'data': example_dataset.data,
+              'data_err': example_dataset.data_err,
+              'response': example_dataset.response,
+              'response_err': example_dataset.response_err,
+              'efficiencies': example_dataset.efficiencies,
+              'efficiencies_err': example_dataset.efficiencies_err
+              }
+    unfolded_result = iterative_unfold(return_iterations=True, **inputs)
+    for _, row in unfolded_result.iterrows():
+        np.testing.assert_array_equal(row['unfolded'],
+                                      np.dot(inputs['data'], row['unfolding_matrix']))

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -205,7 +205,8 @@ def _unfold(prior=None, mixer=None, ts_func=None, max_iter=100,
         status = {'unfolded': unfolded_n_c,
                   'stat_err': mixer.get_stat_err(),
                   'sys_err': mixer.get_MC_err(),
-                  'num_iterations': iteration}
+                  'num_iterations': iteration,
+                  'unfolding_matrix': mixer.Mij}
 
         if regularizer is not None:
             # Will want the nonregularized distribution for the final iteration


### PR DESCRIPTION
This PR adds the unfolding matrix to the returned output from `iterative_unfold`

- [x] Tests added / passed
- [x] Passes `flake8 pyunfold`
