### PR TITLE
Adds 2D response matrix check

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,7 +16,7 @@ Version 0.5.dev0 (TBD)
 
 **Changes**:
 
--
+- Adds a check to ``Mixer`` to ensure response matrices are two-dimensional. An error is raised if a non-2D response matrix is input (See `PR #90 <https://github.com/jrbourbeau/pyunfold/pull/90>`_).
 
 
 **Bug Fixes**:

--- a/pyunfold/mix.py
+++ b/pyunfold/mix.py
@@ -19,6 +19,11 @@ class Mixer(object):
                        'effect bins.'.format(len(data), response.shape[0]))
             raise ValueError(err_msg)
 
+        if response.ndim != 2:
+            raise ValueError('Response matrix must be 2-dimensional, but got '
+                             'a {}-dimensional response matrix '
+                             'instead'.format(response.ndim))
+
         # Normalized P(E|C)
         self.pec = response
         self.cEff = efficiencies

--- a/pyunfold/tests/test_mix.py
+++ b/pyunfold/tests/test_mix.py
@@ -67,3 +67,20 @@ def test_mixer_smear_invalid_cause_bins_raises():
 def test_mixer_zeros_prior():
     np.testing.assert_array_equal(mixer.smear(np.zeros(num_causes)),
                                   np.zeros(num_causes))
+
+
+def test_mixer_2d_response_check():
+    response = 1 + np.random.rand(num_effects, num_causes, num_effects)
+    response_err = np.sqrt(response)
+
+    with pytest.raises(ValueError) as excinfo:
+        Mixer(data=data,
+              data_err=data_err,
+              efficiencies=efficiencies,
+              efficiencies_err=efficiencies_err,
+              response=response,
+              response_err=response_err)
+
+    raised_msg = str(excinfo.value)
+    assert 'Response matrix must be 2-dimensional' in raised_msg
+    assert '{}-dimensional response'.format(response.ndim) in raised_msg

--- a/pyunfold/tests/test_mix.py
+++ b/pyunfold/tests/test_mix.py
@@ -70,17 +70,19 @@ def test_mixer_zeros_prior():
 
 
 def test_mixer_2d_response_check():
-    response = 1 + np.random.rand(num_effects, num_causes, num_effects)
-    response_err = np.sqrt(response)
+    # Tests that a non-2D response matrix raises an error
+    # Construct a response matrix that is 3-dimensional
+    response_bad = 1 + np.random.rand(num_effects, num_causes, 1)
+    response_bad_err = np.sqrt(response_bad)
 
     with pytest.raises(ValueError) as excinfo:
         Mixer(data=data,
               data_err=data_err,
               efficiencies=efficiencies,
               efficiencies_err=efficiencies_err,
-              response=response,
-              response_err=response_err)
+              response=response_bad,
+              response_err=response_bad_err)
 
     raised_msg = str(excinfo.value)
     assert 'Response matrix must be 2-dimensional' in raised_msg
-    assert '{}-dimensional response'.format(response.ndim) in raised_msg
+    assert '{}-dimensional response'.format(response_bad.ndim) in raised_msg


### PR DESCRIPTION
This PR adds a check that input response matrices are 2-dimensional. Now a more meaningful error message will be raised when a non-2D response matrix is used. 

Ref: #89

- [x] Tests added / passed
- [x] Passes `flake8 pyunfold`
