### PR TITLE
Fixes bug in BF calc method

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,7 +21,7 @@ Version 0.5.dev0 (TBD)
 
 **Bug Fixes**:
 
--
+- Fixed bug in Bayes factor test statistic ``calc`` method (See `PR #93 <https://github.com/jrbourbeau/pyunfold/pull/93>`_).
 
 
 Version 0.4 (2018-06-03)

--- a/pyunfold/tests/test_teststat.py
+++ b/pyunfold/tests/test_teststat.py
@@ -4,12 +4,8 @@ import pytest
 from pyunfold.teststat import get_ts, TEST_STATISTICS
 
 
-@pytest.mark.parametrize('name', ['ks',
-                                  'chi2',
-                                  'bf',
-                                  'rmd'])
+@pytest.mark.parametrize('name', TEST_STATISTICS.keys())
 def test_get_ts(name):
-    assert name in TEST_STATISTICS.keys()
     assert get_ts(name) in TEST_STATISTICS.values()
 
 
@@ -18,6 +14,17 @@ def test_get_ts_raises():
     with pytest.raises(ValueError) as excinfo:
         get_ts(name)
 
-    expected_msg = ('Invalid test statisitc, {}, entered. Must be '
+    expected_msg = ('Invalid test statistic, {}, entered. Must be '
                     'in {}'.format(name, TEST_STATISTICS.keys()))
     assert expected_msg == str(excinfo.value)
+
+
+@pytest.mark.parametrize('ts', TEST_STATISTICS.keys())
+def test_ts_calc(ts, example_dataset):
+    # Regression test for issue #92
+    ts_obj = get_ts(ts)
+    ts_func = ts_obj(tol=0.01,
+                     num_causes=len(example_dataset.data),
+                     TestRange=[0, 1e2],
+                     verbose=False)
+    ts_func.calc(example_dataset.data, example_dataset.data + 1)

--- a/pyunfold/teststat.py
+++ b/pyunfold/teststat.py
@@ -158,7 +158,6 @@ class BF(TestStat):
         for i in range(0, len(dist1)):
             lnB += lgamma(dist1[i]+1) + lgamma(dist2[i]+1) - lgamma(dist1[i]+dist2[i]+2)
 
-        self.SetStat(lnB)
         self.stat = lnB
 
         return lnB
@@ -253,5 +252,5 @@ def get_ts(name='ks'):
         ts = TEST_STATISTICS[name]
         return ts
     else:
-        raise ValueError('Invalid test statisitc, {}, entered. Must be '
+        raise ValueError('Invalid test statistic, {}, entered. Must be '
                          'in {}'.format(name, TEST_STATISTICS.keys()))


### PR DESCRIPTION
This PR removes the call to a non-existent `SetStat` method in the `BF.calc` method. Also adds a test to ensure that the `calc` method for each test statistic can be called without raising an error. 

Fixes #92.

- [x] Tests added / passed
- [x] Passes `flake8 pyunfold`
