### PR TITLE
[DOC] reorganize examples

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -1,4 +1,4 @@
-.. _advanced:
+.. _examples:
 
 :github_url: https://github.com/jrbourbeau/pyunfold
 
@@ -11,6 +11,7 @@ There are several advanced unfolding techniques that PyUnfold supports. Most not
 .. toctree::
     :maxdepth: 1
 
+    Basic API Tutorial <notebooks/tutorial.ipynb>
     Implementing a user-defined prior <notebooks/user_prior.ipynb>
     Smoothing via spline regularization <notebooks/regularization.ipynb>
     Multivariate unfolding via cause groups <notebooks/multivariate.ipynb>

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -2,9 +2,9 @@
 
 :github_url: https://github.com/jrbourbeau/pyunfold
 
-*******************
-Advanced Techniques
-*******************
+********
+Examples
+********
 
 There are several advanced unfolding techniques that PyUnfold supports. Most notably these include:
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -6,8 +6,6 @@
 Examples
 ********
 
-There are several advanced unfolding techniques that PyUnfold supports. Most notably these include:
-
 .. toctree::
     :maxdepth: 1
 
@@ -19,7 +17,8 @@ There are several advanced unfolding techniques that PyUnfold supports. Most not
 
 The above links lead to example notebooks that walk through each of these techniques.
 
-These example notebooks can also be launched on a live notebook server using `Binder <https://mybinder.org/>`_. To launch a notebook server click the badge below
+These example notebooks can also be launched on a live notebook server using
+`Binder <https://mybinder.org/>`_. To launch a notebook server click the badge below
 
 .. image:: https://mybinder.org/badge.svg
     :target: https://mybinder.org/v2/gh/jrbourbeau/pyunfold/master?filepath=docs%2Fsource%2Fnotebooks

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ PyUnfold provides an unfolding toolkit for members of all scientific disciplines
     overview
     why
     installation
-    Tutorial <notebooks/tutorial.ipynb>
+    examples
 
 .. toctree::
     :maxdepth: 1
@@ -53,7 +53,6 @@ PyUnfold provides an unfolding toolkit for members of all scientific disciplines
 
     callbacks
     api
-    advanced
     mathematics
     changelog
     contributing


### PR DESCRIPTION
Closes #94.

Promoted examples to go right below installation:

<img width="765" alt="screen shot 2018-09-03 at 10 29 54 am" src="https://user-images.githubusercontent.com/1320475/44994447-3be6d300-af8e-11e8-9684-a5d2256c685e.png">

