### PR TITLE
Add nbsphinx prolog

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - matplotlib
+  - seaborn
   - pip:
       - git+https://github.com/jrbourbeau/pyunfold.git

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,9 +26,9 @@ copyright = u'2018, James Bourbeau, Zigfried Hampel-Arias'
 author = u'James Bourbeau, Zigfried Hampel-Arias'
 
 # The short X.Y version
-version = ''
+# version = ''
 # The full version, including alpha/beta/rc tags
-release = ''
+release = pyunfold.__version__
 
 
 # -- General configuration ---------------------------------------------------
@@ -54,6 +54,28 @@ numpydoc_show_inherited_class_members = False
 # this is needed for some reason...
 # see https://github.com/numpy/numpydoc/issues/69
 numpydoc_class_members_toctree = False
+
+# This is processed by Jinja2 and inserted before each notebook
+nbsphinx_prolog = """
+{% set docname = env.doc2path(env.docname, base='docs/source') %}
+
+.. only:: html
+
+    .. role:: raw-html(raw)
+        :format: html
+
+    .. note::
+
+        This page was generated from `{{ docname }}`__.
+        An interactive version of this notebook can be run using `Binder <https://mybinder.org/>`_ by clicking
+        :raw-html:`<a href="https://mybinder.org/v2/gh/jrbourbeau/pyunfold/master?filepath={{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge.svg" style="vertical-align:text-bottom"></a>`
+
+        Note that if you wish to run this notebook on your own, you'll need to have `matplotlib <https://matplotlib.org/>`_ and `seaborn <https://seaborn.pydata.org/>`_ installed.
+
+
+    __ https://github.com/jrbourbeau/pyunfold/blob/master/{{ docname }}
+
+"""
 
 autosummary_generate = ['api.rst']
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,9 +43,9 @@ PyUnfold provides an unfolding toolkit for members of all scientific disciplines
     :caption: Getting Started
 
     overview
-    why
     installation
     examples
+    why
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/notebooks/multivariate.ipynb
+++ b/docs/source/notebooks/multivariate.ipynb
@@ -25,16 +25,21 @@
    "source": [
     "import numpy as np\n",
     "np.random.seed(2)\n",
-    "\n",
-    "import matplotlib as mpl\n",
-    "mpl.rcParams['font.size'] = 16.0\n",
-    "mpl.rcParams['axes.labelsize'] = 16.0\n",
-    "mpl.rcParams['axes.titlesize'] = 14.0\n",
-    "mpl.rcParams['legend.fontsize'] = 12.0\n",
-    "\n",
     "import matplotlib.pyplot as plt \n",
+    "import seaborn as sns\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.set_context(context='poster')\n",
+    "plt.rcParams['figure.figsize'] = (10, 8)\n",
+    "plt.rcParams['lines.markeredgewidth'] = 2"
    ]
   },
   {
@@ -94,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(len(data_true)), data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True distribution')\n",
     "ax.step(np.arange(len(data_observed)), data_observed, where='mid', lw=3,\n",
@@ -117,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "im = ax.imshow(response, origin='lower')\n",
     "cbar = plt.colorbar(im, label='$P(E_i|C_{\\mu})$')\n",
     "ax.set(xlabel='Cause bins', ylabel='Effect bins',\n",
@@ -225,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.errorbar(np.arange(num_causes), unfolded_results_groups['unfolded'],\n",
     "            yerr=unfolded_results_groups['sys_err'],\n",
     "            alpha=0.7,\n",
@@ -269,7 +274,7 @@
    "outputs": [],
    "source": [
     "# Cause limits\n",
-    "cause_lim = np.logspace(0, 3, num_causes//2)"
+    "cause_lim = np.logspace(0, 3, num_causes // 2)"
    ]
   },
   {
@@ -289,7 +294,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_causes), prior_jeff_groups, where='mid', lw=3,\n",
     "        alpha=0.8)\n",
     "ax.set(xlabel='Cause bins', ylabel='$P(C_{\\mu})$',\n",
@@ -322,7 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "plt.errorbar(np.arange(num_causes), unfolded_results_groups_jeff['unfolded'],\n",
     "             yerr=unfolded_results_groups_jeff['sys_err'],\n",
     "             alpha=0.7,\n",
@@ -411,7 +416,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.errorbar(np.arange(num_causes), unfolded_results_groups_reg['unfolded'],\n",
     "            yerr=unfolded_results_groups_reg['sys_err'],\n",
     "            alpha=0.7,\n",
@@ -531,7 +536,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_causes), group_data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True Distribution')\n",
     "\n",
@@ -604,7 +609,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_causes), group_data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True Distribution')\n",
     "\n",
@@ -743,7 +748,7 @@
    "outputs": [],
    "source": [
     "# Extend range of bins\n",
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_causes), group_data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True Distribution')\n",
     "\n",

--- a/docs/source/notebooks/regularization.ipynb
+++ b/docs/source/notebooks/regularization.ipynb
@@ -25,16 +25,21 @@
    "source": [
     "import numpy as np\n",
     "np.random.seed(2)\n",
-    "\n",
-    "import matplotlib as mpl\n",
-    "mpl.rcParams['font.size'] = 16.0\n",
-    "mpl.rcParams['axes.labelsize'] = 16.0\n",
-    "mpl.rcParams['axes.titlesize'] = 14.0\n",
-    "mpl.rcParams['legend.fontsize'] = 12.0\n",
-    "\n",
     "import matplotlib.pyplot as plt \n",
+    "import seaborn as sns\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.set_context(context='poster')\n",
+    "plt.rcParams['figure.figsize'] = (10, 8)\n",
+    "plt.rcParams['lines.markeredgewidth'] = 2"
    ]
   },
   {
@@ -94,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_causes), data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True distribution')\n",
     "ax.step(np.arange(num_causes), data_observed, where='mid', lw=3,\n",
@@ -117,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "im = ax.imshow(response, origin='lower')\n",
     "cbar = plt.colorbar(im, label='$P(E_i|C_{\\mu})$')\n",
     "ax.set(xlabel='Cause bins', ylabel='Effect bins',\n",
@@ -176,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "plt.step(np.arange(num_causes), uni_prior, where='mid', lw=3,\n",
     "         alpha=0.7, label='Uniform')\n",
     "plt.step(np.arange(num_causes), bumpy_prior, where='mid', lw=3,\n",
@@ -226,7 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "plt.step(np.arange(num_causes), data_true, where='mid', lw=3,\n",
     "         alpha=0.7,\n",
     "         label='True distribution')\n",
@@ -313,7 +318,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "plt.step(np.arange(num_causes), data_true, where='mid', lw=3,\n",
     "         alpha=0.7,\n",
     "         label='True distribution')\n",
@@ -349,27 +354,6 @@
     "\n",
     "For this example, a strong regularization parameter (`smooth = 5e6`) was needed to return consistent unfolded results. Assuming a smooth initial prior is the proper way to avoid this potential issue, unless one does indeed have overriding assumptions regarding smoothness."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/notebooks/tutorial.ipynb
+++ b/docs/source/notebooks/tutorial.ipynb
@@ -6,7 +6,6 @@
    "source": [
     "# PyUnfold Tutorial\n",
     "\n",
-    "This tutorial can be launched on an interactive notebook server using [Binder](https://mybinder.org/). You can open a notebook server [here](https://mybinder.org/v2/gh/jrbourbeau/pyunfold/master?filepath=docs%2Fsource%2Fnotebooks%2Ftutorial.ipynb). In addition, note that if you wish to run this notebook on your own, you'll need to have `matplotlib` installed. \n",
     "\n",
     "PyUnfold uses the `iterative_unfold` function to perform iterative unfoldings. In addition, we'll use the `Logger` callback (see the [Callbacks documentation](../callbacks.rst) for more information) to display the unfolding status at each iteration. "
    ]
@@ -29,16 +28,21 @@
    "source": [
     "import numpy as np\n",
     "np.random.seed(2)\n",
-    "\n",
-    "import matplotlib as mpl\n",
-    "mpl.rcParams['font.size'] = 16.0\n",
-    "mpl.rcParams['axes.labelsize'] = 16.0\n",
-    "mpl.rcParams['axes.titlesize'] = 14.0\n",
-    "mpl.rcParams['legend.fontsize'] = 12.0\n",
-    "\n",
     "import matplotlib.pyplot as plt \n",
+    "import seaborn as sns\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.set_context(context='poster')\n",
+    "plt.rcParams['figure.figsize'] = (10, 8)\n",
+    "plt.rcParams['lines.markeredgewidth'] = 2"
    ]
   },
   {
@@ -106,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_bins), data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True distribution')\n",
     "ax.set(xlabel='X bins', ylabel='Counts')\n",
@@ -170,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_bins), data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True distribution')\n",
     "ax.step(np.arange(num_bins), data_observed, where='mid', lw=3,\n",
@@ -275,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "im = ax.imshow(response_hist, origin='lower')\n",
     "cbar = plt.colorbar(im, label='Counts')\n",
     "ax.set(xlabel='Cause bins', ylabel='Effect bins')\n",
@@ -340,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "im = ax.imshow(response, origin='lower')\n",
     "cbar = plt.colorbar(im, label='$P(E_i|C_{\\mu})$')\n",
     "ax.set(xlabel='Cause bins', ylabel='Effect bins',\n",
@@ -396,7 +400,8 @@
     "- Systematic uncertainties on the unfolded distribution based on the response matrix uncertainties (`sys_err` key)\n",
     "- Number of unfolding iterations to reach test statistic stopping condition (`num_iterations` key)\n",
     "- Test statistic value for final iteration (`ts_iter` key)\n",
-    "- Test statistic stopping condition (`ts_stopping` key)"
+    "- Test statistic stopping condition (`ts_stopping` key)\n",
+    "- Unfolding matrix (`unfolding_matrix` key)"
    ]
   },
   {
@@ -405,7 +410,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unfolded_results"
+    "unfolded_results.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unfolded_results['unfolded']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unfolded_results['sys_err']"
    ]
   },
   {
@@ -421,7 +444,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "fig, ax = plt.subplots()\n",
     "ax.step(np.arange(num_bins), data_true, where='mid', lw=3,\n",
     "        alpha=0.7, label='True distribution')\n",
     "ax.step(np.arange(num_bins), data_observed, where='mid', lw=3,\n",
@@ -445,13 +468,6 @@
    "source": [
     "Note that the unfolded distribution is consistent with the true distribution! "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/notebooks/user_prior.ipynb
+++ b/docs/source/notebooks/user_prior.ipynb
@@ -25,16 +25,21 @@
    "source": [
     "import numpy as np\n",
     "np.random.seed(2)\n",
-    "\n",
-    "import matplotlib as mpl\n",
-    "mpl.rcParams['font.size'] = 16.0\n",
-    "mpl.rcParams['axes.labelsize'] = 16.0\n",
-    "mpl.rcParams['axes.titlesize'] = 14.0\n",
-    "mpl.rcParams['legend.fontsize'] = 12.0\n",
-    "\n",
     "import matplotlib.pyplot as plt \n",
+    "import seaborn as sns\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.set_context(context='poster')\n",
+    "plt.rcParams['figure.figsize'] = (10, 8)\n",
+    "plt.rcParams['lines.markeredgewidth'] = 2"
    ]
   },
   {
@@ -301,13 +306,6 @@
     "\n",
     "For information about how un-smooth priors can affect an unfolding see the [smoothing via spline regularization example](regularization.ipynb)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR adds a `nbsphinx_prolog` that gets rendered at the top of each example notebook. The added content links to the corresponding interactive notebook on Binder (see screenshot below). The idea here is that this will bring more attention to the interactive notebooks. 

<img width="1036" alt="screen shot 2018-09-03 at 1 18 26 pm" src="https://user-images.githubusercontent.com/11656932/44998692-18675c80-af7d-11e8-9da0-a4592a223ab8.png">

Ref: #94

