### PR TITLE
Removes unnecessary array copying

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,7 @@ Version 0.5.dev0 (TBD)
 **Changes**:
 
 - Adds a check to ``Mixer`` to ensure response matrices are two-dimensional. An error is raised if a non-2D response matrix is input (See `PR #90 <https://github.com/jrbourbeau/pyunfold/pull/90>`_).
+- Removes unnecessary NumPy array copies in ``Mixer`` and  ``CovarianceMatrix`` object (See `PR #99 <https://github.com/jrbourbeau/pyunfold/pull/99>`_).
 
 
 **Bug Fixes**:

--- a/environment.yml
+++ b/environment.yml
@@ -19,5 +19,6 @@ dependencies:
   - nbsphinx
   - pandoc
   - jupyter
+  - testpath<0.4
   - matplotlib
   - seaborn

--- a/pyunfold/mix.py
+++ b/pyunfold/mix.py
@@ -94,7 +94,7 @@ class Mixer(object):
         n_c_update = np.dot(self.NEobs, Mij)
 
         # The status quo
-        self.Mij = Mij.copy()
+        self.Mij = Mij
         self.cov.set_current_state(self.Mij, f_norm, n_c_update, n_c)
 
         return n_c_update
@@ -130,8 +130,6 @@ class CovarianceMatrix(object):
         dims = self.pec.shape
         self.cbins = dims[1]
         self.ebins = dims[0]
-        # Mixing matrix
-        self.Mij = np.zeros(dims)
         # Adye propagating derivative
         self.dcdn = np.zeros(dims)
         self.dcdP = np.zeros((self.cbins, self.cbins * self.ebins))
@@ -144,9 +142,6 @@ class CovarianceMatrix(object):
         # For ease of typing
         ebins = self.ebins
         cbins = self.cbins
-
-        # First set Mij
-        self.Mij = Mij.copy()
 
         # D'Agostini Form (and/or First Term of Adye)
         dcdn = Mij.copy()
@@ -166,8 +161,8 @@ class CovarianceMatrix(object):
         # Adye propagation corrections
         if self.counter > 0:
             # Get previous derivatives
-            dcdn_prev = self.dcdn.copy()
-            dcdP_prev = self.dcdP.copy()
+            dcdn_prev = self.dcdn
+            dcdP_prev = self.dcdP
 
             n_c_prev_inv = safe_inverse(n_c_prev)
             # Ratio of updated n_c to n_c_prev
@@ -192,8 +187,8 @@ class CovarianceMatrix(object):
             dcdP += (dcdP_prev.T * nc_r).T - dcdP_Upd
 
         # Set current derivative matrices
-        self.dcdn = dcdn.copy()
-        self.dcdP = dcdP.copy()
+        self.dcdn = dcdn
+        self.dcdP = dcdP
         # On to next iteration
         self.counter += 1
 
@@ -207,7 +202,7 @@ class CovarianceMatrix(object):
         """Get full Vc0 (data) contribution to cov matrix
         """
         # Get derivative
-        dcdn = self.dcdn.copy()
+        dcdn = self.dcdn
         # Get NObs covariance
         Vcd = self.getVcd()
         # Set data covariance


### PR DESCRIPTION
This PR removes a few unnecessary NumPy array copies from `mix.py`. I think these copies are left over artifacts from the original PyUnfold implementation. 

- [x] Tests added / passed
- [x] Passes `flake8 pyunfold`
