### PR TITLE
Adds CallbackList

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Version 0.5.dev0 (TBD)
 **New Features**:
 
 - Adds unfolding matrix to output of ``iterative_unfold`` (See `PR #88 <https://github.com/jrbourbeau/pyunfold/pull/88>`_).
+- Adds ``CallbackList`` container for storing a collection of ``Callback`` objects (See `PR #101 <https://github.com/jrbourbeau/pyunfold/pull/101>`_).
 
 
 **Changes**:

--- a/pyunfold/callbacks.py
+++ b/pyunfold/callbacks.py
@@ -165,6 +165,22 @@ class SplineRegularizer(Callback, Regularizer):
 
 
 def validate_callbacks(callbacks):
+    """Checks that input callbacks are indeed Callback object instances
+
+    Parameters
+    ----------
+    callbacks : Callback or iterable
+        Input Callbacks. Can be either a single Callback or an interable
+        of Callbacks.
+
+    Returns
+    -------
+    callbacks : list
+       List of Callbacks. If ``callbacks`` is already a list of ``Callback``
+       objects, then it is returned. If ``callbacks`` is a ``Callback`` object,
+       then a list containing ``callbacks`` is returned. If ``callbacks`` is
+       None, an empty list is returned.
+    """
     if callbacks is None:
         callbacks = []
     elif isinstance(callbacks, Callback):
@@ -178,6 +194,25 @@ def validate_callbacks(callbacks):
 
 
 def extract_regularizer(callbacks):
+    """Returns a Regularizer Callback from an input list of Callbacks
+
+    Parameters
+    ----------
+    callbacks : Callback or iterable
+        Input Callbacks. Can be either a single Callback or an interable
+        of Callbacks.
+
+    Returns
+    -------
+    regularizer : Regularizer
+       Regularizer Callback if one exists in the input callbacks, otherwise
+       None is returned.
+
+    Raises
+    ------
+    NotImplementedError
+        Multiple Regularizers are in the input Callbacks.
+    """
     callbacks = validate_callbacks(callbacks)
     regularizers = [c for c in callbacks if isinstance(c, Regularizer)]
     if len(regularizers) > 1:
@@ -188,6 +223,19 @@ def extract_regularizer(callbacks):
 
 
 def setup_callbacks_regularizer(callbacks):
+    """Validates and formats input callbacks
+
+    Parameters
+    ----------
+    callbacks : Callback or iterable
+        Input Callbacks. Can be either a single Callback or an interable
+        of Callbacks.
+
+    Returns
+    -------
+    callbacks : CallbackList
+    regularizer : Regularizer
+    """
     callbacks = validate_callbacks(callbacks)
     regularizer = extract_regularizer(callbacks)
     callbacks = CallbackList([c for c in callbacks if c is not regularizer])

--- a/pyunfold/callbacks.py
+++ b/pyunfold/callbacks.py
@@ -29,6 +29,9 @@ class CallbackList(object):
     def __init__(self, callbacks=None):
         self.callbacks = validate_callbacks(callbacks)
 
+    def __len__(self):
+        return len(self.callbacks)
+
     def __iter__(self):
         return iter(self.callbacks)
 

--- a/pyunfold/tests/test_callbacks.py
+++ b/pyunfold/tests/test_callbacks.py
@@ -205,3 +205,54 @@ def test_setup_callbacks_regularizer():
     assert len(c) == 1
     assert c.callbacks[0] is callbacks[0]
     assert r is callbacks[1]
+
+
+def test_callbacklist_empty():
+    c = CallbackList()
+    assert c.callbacks == []
+
+
+def test_callbacklist_callbacks():
+    logger = Logger()
+    reg = SplineRegularizer()
+    callbacks = [logger, reg]
+    c = CallbackList(callbacks=callbacks)
+    assert len(c) == len(callbacks)
+    assert all(i is j for i, j in zip(c.callbacks, callbacks))
+
+
+def test_callbacklist_method_calls():
+    class MethodChecker(Callback):
+        def __init__(self):
+            super(Callback, self).__init__()
+            self.called_unfolding_begin = False
+            self.called_on_unfolding_end = False
+            self.called_on_iteration_begin = False
+            self.called_on_iteration_end = False
+
+        def on_unfolding_begin(self, status=None):
+            self.called_on_unfolding_begin = True
+
+        def on_unfolding_end(self, status=None):
+            self.called_on_unfolding_end = True
+
+        def on_iteration_begin(self, iteration, status=None):
+            self.called_on_iteration_begin = True
+
+        def on_iteration_end(self, iteration, status=None):
+            self.called_on_iteration_end = True
+
+    method_checker = MethodChecker()
+    c = CallbackList(method_checker)
+
+    c.on_iteration_begin(1)
+    assert method_checker.called_on_iteration_begin
+
+    c.on_iteration_end(1)
+    assert method_checker.called_on_iteration_end
+
+    c.on_unfolding_begin()
+    assert method_checker.called_on_unfolding_begin
+
+    c.on_unfolding_end()
+    assert method_checker.called_on_unfolding_end

--- a/pyunfold/tests/test_callbacks.py
+++ b/pyunfold/tests/test_callbacks.py
@@ -5,9 +5,10 @@ import pytest
 from scipy.interpolate import UnivariateSpline
 
 from pyunfold.unfold import iterative_unfold
-from pyunfold.callbacks import (Callback, Logger, SplineRegularizer,
-                                Regularizer, validate_callbacks,
-                                extract_regularizer)
+from pyunfold.callbacks import (Callback, CallbackList, Logger,
+                                Regularizer, SplineRegularizer,
+                                validate_callbacks, extract_regularizer,
+                                setup_callbacks_regularizer)
 
 
 @pytest.mark.parametrize('attr', ['on_unfolding_begin',
@@ -194,3 +195,13 @@ def test_extract_regularizer_no_regularizer():
 def test_extract_regularizer(callback):
     callbacks = [Logger(), callback]
     assert extract_regularizer(callbacks) == callback
+
+
+def test_setup_callbacks_regularizer():
+
+    callbacks = [Logger(), SplineRegularizer()]
+    c, r = setup_callbacks_regularizer(callbacks)
+    assert isinstance(c, CallbackList)
+    assert len(c) == 1
+    assert c.callbacks[0] is callbacks[0]
+    assert r is callbacks[1]


### PR DESCRIPTION
This PR adds a `Callback` container object, `CallbackList`, and updates `_unfold` to ensure that the `on_unfolding_begin`/`_end` and `on_iteration_begin`/`_end`  methods are called for each `Callback`. 

- [x] Tests added / passed
- [x] Passes `flake8 pyunfold`
