### PR TITLE
Custom stopping conditions

### DIFF
--- a/pyunfold/callbacks.py
+++ b/pyunfold/callbacks.py
@@ -83,10 +83,8 @@ class Logger(Callback):
         iteration : int
             Unfolding iteration (i.e. iteration=1 after first unfolding
             iteration, etc.).
-        status : dict
-            Dictionary containing key value pairs for the current test
-            statistic value (``'ts_iter'``) and the final test statistic stopping
-            condition (``'ts_stopping'``).
+        status : List[dict]
+            List of dictionaries containing the unfolding status.
         """
         iteration_idx = iteration - 1
         output = ('Iteration {}: ts = {:0.4f}, ts_stopping ='
@@ -268,17 +266,15 @@ class TSStopping(Callback):
                               verbose=False)
 
     def on_iteration_end(self, iteration, status):
-        """Writes to sys.stdout
+        """Calculates test statistic between current and previous unfolded distributions
 
         Parameters
         ----------
         iteration : int
             Unfolding iteration (i.e. iteration=1 after first unfolding
             iteration, etc.).
-        status : dict
-            Dictionary containing key value pairs for the current test
-            statistic value (``'ts_iter'``) and the final test statistic stopping
-            condition (``'ts_stopping'``).
+        status : List[dict]
+            List of dictionaries containing the unfolding status.
         """
         iteration_idx = iteration - 1
         ts_iter = self.ts_func.calc(status[iteration_idx]['unfolded'],

--- a/pyunfold/callbacks.py
+++ b/pyunfold/callbacks.py
@@ -3,6 +3,8 @@ import sys
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 
+from .teststat import get_ts
+
 
 class Callback(object):
     """Callback base class
@@ -34,6 +36,11 @@ class CallbackList(object):
 
     def __iter__(self):
         return iter(self.callbacks)
+
+    def append(self, other):
+        if not isinstance(other, Callback):
+            raise TypeError('Can only append Callback objects to a CallbackList')
+        self.callbacks.append(other)
 
     def on_unfolding_begin(self, status=None):
         for callback in self.callbacks:
@@ -81,10 +88,11 @@ class Logger(Callback):
             statistic value (``'ts_iter'``) and the final test statistic stopping
             condition (``'ts_stopping'``).
         """
+        iteration_idx = iteration - 1
         output = ('Iteration {}: ts = {:0.4f}, ts_stopping ='
                   ' {}\n'.format(iteration,
-                                 status['ts_iter'],
-                                 status['ts_stopping']))
+                                 status[iteration_idx]['ts_iter'],
+                                 status[iteration_idx]['ts_stopping']))
         sys.stdout.write(output)
 
 
@@ -139,7 +147,8 @@ class SplineRegularizer(Callback, Regularizer):
         self.groups = np.asarray(groups) if groups is not None else None
 
     def on_iteration_end(self, iteration, status=None):
-        y = status['unfolded']
+        iteration_idx = iteration - 1
+        y = status[iteration_idx]['unfolded']
         x = np.arange(len(y), dtype=float)
         if self.groups is None:
             spline = UnivariateSpline(x, y, k=self.degree, s=self.smooth)
@@ -161,7 +170,7 @@ class SplineRegularizer(Callback, Regularizer):
                 fitted_unfolded_group = spline_group(x_group)
                 fitted_unfolded[group_mask] = fitted_unfolded_group
 
-        status['unfolded'] = fitted_unfolded
+        status[iteration_idx]['unfolded'] = fitted_unfolded
 
 
 def validate_callbacks(callbacks):
@@ -241,3 +250,40 @@ def setup_callbacks_regularizer(callbacks):
     callbacks = CallbackList([c for c in callbacks if c is not regularizer])
 
     return callbacks, regularizer
+
+
+class TSStopping(Callback):
+    """Unfolded distribution test statistic based stopping
+    """
+    def __init__(self, ts='ks', ts_stopping=0.01, num_causes=None):
+        super(Callback, self).__init__()
+        self.ts = ts
+        self.ts_stopping = ts_stopping
+        self.stop_iterations = False
+        # Setup test statistic calculation
+        ts_obj = get_ts(ts)
+        self.ts_func = ts_obj(tol=ts_stopping,
+                              num_causes=num_causes,
+                              TestRange=[0, 1e2],
+                              verbose=False)
+
+    def on_iteration_end(self, iteration, status):
+        """Writes to sys.stdout
+
+        Parameters
+        ----------
+        iteration : int
+            Unfolding iteration (i.e. iteration=1 after first unfolding
+            iteration, etc.).
+        status : dict
+            Dictionary containing key value pairs for the current test
+            statistic value (``'ts_iter'``) and the final test statistic stopping
+            condition (``'ts_stopping'``).
+        """
+        iteration_idx = iteration - 1
+        ts_iter = self.ts_func.calc(status[iteration_idx]['unfolded'],
+                                    status[iteration_idx]['prior'])
+        status[iteration_idx]['ts_iter'] = ts_iter
+        status[iteration_idx]['ts_stopping'] = self.ts_stopping
+        if ts_iter < self.ts_stopping:
+            self.stop_iterations = True

--- a/pyunfold/tests/test_unfold.py
+++ b/pyunfold/tests/test_unfold.py
@@ -278,3 +278,22 @@ def test_unfolding_matrix(example_dataset):
     for _, row in unfolded_result.iterrows():
         np.testing.assert_array_equal(row['unfolded'],
                                       np.dot(inputs['data'], row['unfolding_matrix']))
+
+
+@pytest.mark.parametrize('ts, ts_stopping', [
+    ('ks', None),
+    (None, 0.11),
+    ('chi2', 0.05),
+])
+def test_iterative_unfold_ts_deprecated(example_dataset, ts, ts_stopping):
+    inputs = {'data': example_dataset.data,
+              'data_err': example_dataset.data_err,
+              'response': example_dataset.response,
+              'response_err': example_dataset.response_err,
+              'efficiencies': example_dataset.efficiencies,
+              'efficiencies_err': example_dataset.efficiencies_err
+              }
+    with pytest.deprecated_call():
+        iterative_unfold(ts=ts,
+                         ts_stopping=ts_stopping,
+                         **inputs)

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -4,16 +4,15 @@ import numpy as np
 import pandas as pd
 
 from .mix import Mixer
-from .teststat import get_ts
 from .priors import setup_prior
 from .utils import cast_to_array
-from .callbacks import setup_callbacks_regularizer
+from .callbacks import setup_callbacks_regularizer, CallbackList, TSStopping
 
 
 def iterative_unfold(data=None, data_err=None, response=None,
                      response_err=None, efficiencies=None,
-                     efficiencies_err=None, prior=None, ts='ks',
-                     ts_stopping=0.01, max_iter=100, cov_type='multinomial',
+                     efficiencies_err=None, prior=None, ts=None,
+                     ts_stopping=None, max_iter=100, cov_type='multinomial',
                      return_iterations=False, callbacks=None):
     """Performs iterative unfolding
 
@@ -152,18 +151,21 @@ def iterative_unfold(data=None, data_err=None, response=None,
                   response_err=response_err,
                   cov_type=cov_type)
 
-    # Setup test statistic
-    ts_obj = get_ts(ts)
-    ts_func = ts_obj(tol=ts_stopping,
-                     num_causes=num_causes,
-                     TestRange=[0, 1e2],
-                     verbose=False)
+    # Set up callbacks, regularizer Callbacks are treated separately
+    callbacks, regularizer = setup_callbacks_regularizer(callbacks)
+
+    # Setup legacy stopping condition
+    if ts is None and ts_stopping is None:
+        stopping = TSStopping(ts='ks',
+                              ts_stopping=0.01,
+                              num_causes=num_causes)
+        callbacks = CallbackList([stopping] + callbacks.callbacks)
 
     unfolding_iters = _unfold(prior=n_c,
                               mixer=mixer,
-                              ts_func=ts_func,
                               max_iter=max_iter,
-                              callbacks=callbacks)
+                              callbacks=callbacks,
+                              regularizer=regularizer)
 
     if return_iterations:
         return unfolding_iters
@@ -172,8 +174,7 @@ def iterative_unfold(data=None, data_err=None, response=None,
         return unfolded_result
 
 
-def _unfold(prior=None, mixer=None, ts_func=None, max_iter=100,
-            callbacks=None):
+def _unfold(prior=None, mixer=None, max_iter=100, callbacks=None, regularizer=None):
     """Perform iterative unfolding
 
     Parameters
@@ -182,8 +183,6 @@ def _unfold(prior=None, mixer=None, ts_func=None, max_iter=100,
         Initial cause distribution.
     mixer : pyunfold.Mix.Mixer
         Mixer to perform the unfolding.
-    ts_func : pyunfold.Utils.TestStat
-        Test statistic object.
     max_iter : int, optional
         Maximum allowed number of iterations to perform.
     callbacks : list, optional
@@ -196,39 +195,41 @@ def _unfold(prior=None, mixer=None, ts_func=None, max_iter=100,
         DataFrame containing the unfolded result for each iteration.
         Each row in unfolding_result corresponds to an iteration.
     """
-    # Set up callbacks, regularizer Callbacks are treated separately
-    callbacks, regularizer = setup_callbacks_regularizer(callbacks)
     callbacks.on_unfolding_begin()
 
     current_n_c = prior.copy()
     iteration = 0
     unfolding_iters = []
-    while not ts_func.pass_tol() and iteration < max_iter:
+    status = []
+    stop_iterations = False
+    while not stop_iterations and iteration < max_iter:
         callbacks.on_iteration_begin(iteration=iteration)
 
         # Perform unfolding for this iteration
         unfolded_n_c = mixer.smear(current_n_c)
         iteration += 1
-        status = {'unfolded': unfolded_n_c,
-                  'stat_err': mixer.get_stat_err(),
-                  'sys_err': mixer.get_MC_err(),
-                  'num_iterations': iteration,
-                  'unfolding_matrix': mixer.Mij}
+        iteration_idx = iteration - 1
+        status_current = {'unfolded': unfolded_n_c,
+                          'stat_err': mixer.get_stat_err(),
+                          'sys_err': mixer.get_MC_err(),
+                          'num_iterations': iteration,
+                          'unfolding_matrix': mixer.Mij,
+                          'prior': current_n_c}
+        status.append(status_current)
 
         if regularizer:
             # Will want the nonregularized distribution for the final iteration
-            unfolded_nonregularized = status['unfolded'].copy()
+            unfolded_nonregularized = status[iteration_idx]['unfolded'].copy()
             regularizer.on_iteration_end(iteration=iteration, status=status)
 
-        ts_iter = ts_func.calc(status['unfolded'], current_n_c)
-        status['ts_iter'] = ts_iter
-        status['ts_stopping'] = ts_func.tol
-
         callbacks.on_iteration_end(iteration=iteration, status=status)
-        unfolding_iters.append(status)
+        unfolding_iters.append(status_current)
 
         # Updated current distribution for next iteration of unfolding
-        current_n_c = status['unfolded'].copy()
+        current_n_c = status[iteration_idx]['unfolded'].copy()
+
+        # Check unfolding stopping condition
+        stop_iterations = any([getattr(c, 'stop_iterations', None) for c in callbacks])
 
     # Convert unfolding_iters list of dictionaries to a pandas DataFrame
     unfolding_iters = pd.DataFrame.from_records(unfolding_iters)

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -1,5 +1,6 @@
 
 from __future__ import division, print_function
+import warnings
 import numpy as np
 import pandas as pd
 
@@ -156,10 +157,23 @@ def iterative_unfold(data=None, data_err=None, response=None,
     # Set up callbacks, regularizer Callbacks are treated separately
     callbacks, regularizer = setup_callbacks_regularizer(callbacks)
 
-    # Setup legacy stopping condition
     if ts is None and ts_stopping is None:
+        # Setup legacy stopping condition behavior
         stopping = TSStopping(ts='ks',
                               ts_stopping=0.01,
+                              num_causes=num_causes)
+        callbacks = CallbackList([stopping] + callbacks.callbacks)
+    elif any([ts, ts_stopping]):
+        msg = ('Using ts and ts_stopping parameters in iterative_unfold has '
+               'been deprecated. Please use the TSStopping callback instead.')
+        warnings.warn(msg, DeprecationWarning)
+
+        if ts is None:
+            ts = 'ks'
+        if ts_stopping is None:
+            ts_stopping = 0.01
+        stopping = TSStopping(ts=ts,
+                              ts_stopping=ts_stopping,
                               num_causes=num_causes)
         callbacks = CallbackList([stopping] + callbacks.callbacks)
 


### PR DESCRIPTION
This PR adds support for user-defined stopping condition.

Here, I'll just focus on implementing a test statistic-based stopping condition so we can support the current default behavior of `iterative_unfold`. However, in the future we should expand the available stopping conditions. 

Closes #105

- [ ] Tests added / passed
- [ ] Passes `flake8 pyunfold`
