### PR TITLE
Manage memory

### DIFF
--- a/pyunfold/mix.py
+++ b/pyunfold/mix.py
@@ -11,7 +11,7 @@ class Mixer(object):
     """
     def __init__(self, data=None, data_err=None, efficiencies=None,
                  efficiencies_err=None, response=None, response_err=None,
-                 cov_type='multinomial'):
+                 cov_type='multinomial', dtype=np.float64):
         # Input validation
         if len(data) != response.shape[0]:
             err_msg = ('Inconsistent number of effect bins. Observed data '
@@ -43,7 +43,8 @@ class Mixer(object):
                                     efficiencies_err=efficiencies_err,
                                     response=response,
                                     response_err=response_err,
-                                    cov_type=cov_type)
+                                    cov_type=cov_type,
+                                    dtype=dtype)
 
     def get_cov(self):
         """Covariance Matrix

--- a/pyunfold/mix.py
+++ b/pyunfold/mix.py
@@ -234,11 +234,15 @@ class CovarianceMatrix(object):
 
         # Poisson covariance matrix
         if self.pec_cov_type == 'poisson':
-            CovPP = poisson_covariance(ebins, cbins, self.pec_err)
+            CovPP = poisson_covariance(
+                ebins, cbins, self.pec_err, dtype=self.dtype
+            )
         # Multinomial covariance matrix
         elif self.pec_cov_type == 'multinomial':
             nc_inv = safe_inverse(self.NCmc)
-            CovPP = multinomial_covariance(ebins, cbins, nc_inv, self.pec)
+            CovPP = multinomial_covariance(
+                ebins, cbins, nc_inv, self.pec, dtype=self.dtype
+            )
 
         return CovPP
 

--- a/pyunfold/unfold.py
+++ b/pyunfold/unfold.py
@@ -14,7 +14,8 @@ def iterative_unfold(data=None, data_err=None, response=None,
                      response_err=None, efficiencies=None,
                      efficiencies_err=None, prior=None, ts='ks',
                      ts_stopping=0.01, max_iter=100, cov_type='multinomial',
-                     return_iterations=False, callbacks=None):
+                     return_iterations=False, callbacks=None,
+                     dtype=np.float64):
     """Performs iterative unfolding
 
     Parameters
@@ -150,7 +151,8 @@ def iterative_unfold(data=None, data_err=None, response=None,
                   efficiencies_err=efficiencies_err,
                   response=response,
                   response_err=response_err,
-                  cov_type=cov_type)
+                  cov_type=cov_type,
+                  dtype=dtype)
 
     # Setup test statistic
     ts_obj = get_ts(ts)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 pyunfold`

This PR allows one to set the `dtype` and max memory allowed for the `CovarianceMatrix`---handy when response matrices start getting large.

I branched off of my other PR branch `sparse_poisson` by mistake, but if there's interest in merging this without that branch, it can be redone.

Tests pass on my machine with `dtype=np.float64`, but not with `dtype=np.float32`---small precision differences apparently fall outside the `rtol` of some of the comparisons.

As before, CI tests here fail due to timeouts